### PR TITLE
Update CI to send coverage of devel and main to sonarcloud

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,6 +1,11 @@
 name: Running Code Coverage
 
-on: [pull_request]
+on: 
+  pull_request:
+  push:
+    branches:
+      - devel
+      - main
 
 jobs:
   run_test:

--- a/.github/workflows/release-ci-homolog.yml
+++ b/.github/workflows/release-ci-homolog.yml
@@ -44,6 +44,18 @@ jobs:
           expo-username: ${{ secrets.EXPO_CLI_USERNAME }}
           expo-password: ${{ secrets.EXPO_CLI_PASSWORD }}
 
+      - name: Pushes sonar file
+        uses: dmnemec/copy_file_to_another_repo_action@v1.1.1
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.GIT_TOKEN }}
+        with:
+          source_file: ${{ steps.report.outputs.report_file_name }}.json
+          destination_repo: "fga-eps-mds/2021.1-Pro-Especies-Docs"
+          destination_folder: "analytics-raw-data"
+          user_email: ${{ secrets.GIT_EMAIL}}
+          user_name: ${{ secrets.GIT_USER }}
+          commit_message: Upload a new metrics from ${{ github.event.repository.name }}
+
       - name: Install Turtle
         run: |
           yarn install
@@ -82,16 +94,3 @@ jobs:
           artifacts: |
             ${{ steps.report.outputs.report_file_name }}.json ,
             expo-project.apk
-      
-      - name: Pushes sonar file
-        uses: dmnemec/copy_file_to_another_repo_action@v1.1.1
-        env:
-          API_TOKEN_GITHUB: ${{ secrets.GIT_TOKEN }}
-        with:
-          source_file: ${{ steps.report.outputs.report_file_name }}.json
-          destination_repo: "fga-eps-mds/2021.1-Pro-Especies-Docs"
-          destination_folder: "analytics-raw-data"
-          user_email: ${{ secrets.GIT_EMAIL}}
-          user_name: ${{ secrets.GIT_USER }}
-          commit_message: Upload a new metrics from ${{ github.event.repository.name }}
-


### PR DESCRIPTION
Resolve [#161](https://github.com/fga-eps-mds/2021.1-pro-especies-docs/issues/161)